### PR TITLE
:bug: Bug fix - build using `ts-patch`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,10 +28,10 @@
         "@types/node": "^18.7.18",
         "@types/url-join": "^4.0.1",
         "ts-node": "^10.9.1",
-        "ts-patch": "^3.1.2",
+        "ts-patch": "^3.2.1",
         "tsconfig-paths": "^4.1.0",
         "typescript": "^5.4.5",
-        "typescript-transform-paths": "^3.3.1"
+        "typescript-transform-paths": "^3.5.2"
       }
     },
     "node_modules/@babel/runtime": {
@@ -460,13 +460,12 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -548,12 +547,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1131,15 +1124,18 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -1527,9 +1523,9 @@
       }
     },
     "node_modules/ts-patch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/ts-patch/-/ts-patch-3.1.2.tgz",
-      "integrity": "sha512-n58F5AqjUMdp9RAKq+E1YBkmONltPVbt1nN+wrmZXoYZek6QcvaTuqvKMhYhr5BxtC53kD/exxIPA1cP1RQxsA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ts-patch/-/ts-patch-3.2.1.tgz",
+      "integrity": "sha512-hlR43v+GUIUy8/ZGFP1DquEqPh7PFKQdDMTAmYt671kCCA6AkDQMoeFaFmZ7ObPLYOmpMgyKUqL1C+coFMf30w==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
@@ -1584,12 +1580,12 @@
       }
     },
     "node_modules/typescript-transform-paths": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/typescript-transform-paths/-/typescript-transform-paths-3.3.1.tgz",
-      "integrity": "sha512-c+8Cqd2rsRtTU68rJI0NX/OtqgBDddNs1fIxm1nCNyhn0WpoyqtpUxc1w9Ke5c5kgE4/OT5xYbKf2cf694RYEg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/typescript-transform-paths/-/typescript-transform-paths-3.5.2.tgz",
+      "integrity": "sha512-IRDVXfU7oscLwTvLabXprFrFCMUdBJbdUDtxbHFEsau9FlqrrdgS8PfwUltKDAh75vJFkQ8QdXAt/nzIWWp+fA==",
       "dev": true,
       "dependencies": {
-        "minimatch": "^3.0.4"
+        "minimatch": "^9.0.5"
       },
       "peerDependencies": {
         "typescript": ">=3.6.5"
@@ -2043,13 +2039,12 @@
       "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A=="
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "buffer-equal-constant-time": {
@@ -2119,12 +2114,6 @@
       "requires": {
         "mime-db": ">= 1.43.0 < 2"
       }
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
     },
     "create-require": {
       "version": "1.1.1",
@@ -2584,12 +2573,12 @@
       }
     },
     "minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       }
     },
     "minimist": {
@@ -2864,9 +2853,9 @@
       }
     },
     "ts-patch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/ts-patch/-/ts-patch-3.1.2.tgz",
-      "integrity": "sha512-n58F5AqjUMdp9RAKq+E1YBkmONltPVbt1nN+wrmZXoYZek6QcvaTuqvKMhYhr5BxtC53kD/exxIPA1cP1RQxsA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ts-patch/-/ts-patch-3.2.1.tgz",
+      "integrity": "sha512-hlR43v+GUIUy8/ZGFP1DquEqPh7PFKQdDMTAmYt671kCCA6AkDQMoeFaFmZ7ObPLYOmpMgyKUqL1C+coFMf30w==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",
@@ -2903,12 +2892,12 @@
       "dev": true
     },
     "typescript-transform-paths": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/typescript-transform-paths/-/typescript-transform-paths-3.3.1.tgz",
-      "integrity": "sha512-c+8Cqd2rsRtTU68rJI0NX/OtqgBDddNs1fIxm1nCNyhn0WpoyqtpUxc1w9Ke5c5kgE4/OT5xYbKf2cf694RYEg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/typescript-transform-paths/-/typescript-transform-paths-3.5.2.tgz",
+      "integrity": "sha512-IRDVXfU7oscLwTvLabXprFrFCMUdBJbdUDtxbHFEsau9FlqrrdgS8PfwUltKDAh75vJFkQ8QdXAt/nzIWWp+fA==",
       "dev": true,
       "requires": {
-        "minimatch": "^3.0.4"
+        "minimatch": "^9.0.5"
       }
     },
     "url-join": {

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "@types/node": "^18.7.18",
     "@types/url-join": "^4.0.1",
     "ts-node": "^10.9.1",
-    "ts-patch": "^3.1.2",
+    "ts-patch": "^3.2.1",
     "tsconfig-paths": "^4.1.0",
     "typescript": "^5.4.5",
-    "typescript-transform-paths": "^3.3.1"
+    "typescript-transform-paths": "^3.5.2"
   },
   "prettier": {
     "printWidth": 120,


### PR DESCRIPTION
# Issue Description: 
Running compiled `.js` files is failing to run. 

**Error**:
```
TypeError [ERR_INVALID_ARG_TYPE]: The "id" argument must be of type string. Received undefined
    at Module.require (node:internal/modules/cjs/loader:1333:3)
    at require (node:internal/modules/helpers:141:16)
    at Object.<anonymous> (/app/index.js:44:1)
    at Module._compile (node:internal/modules/cjs/loader:1546:14)
    at Object..js (node:internal/modules/cjs/loader:1689:10)
    at Module.load (node:internal/modules/cjs/loader:1318:32)
    at Function._load (node:internal/modules/cjs/loader:1128:12)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:218:24)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:170:5) {
  code: 'ERR_INVALID_ARG_TYPE'
}

Node.js v22.11.0
```


## Solution:
Typescript compiler is not transforming alias paths. Updating `ts-patch` to `3.2.1` and `typescript-transform-paths` to `3.5.2` solves the issue.